### PR TITLE
Fix `/pc` overriding last saved box & update mod version

### DIFF
--- a/common/src/main/java/me/justahuman/more_cobblemon_tweaks/mixins/PcGuiMixin.java
+++ b/common/src/main/java/me/justahuman/more_cobblemon_tweaks/mixins/PcGuiMixin.java
@@ -1,6 +1,7 @@
 package me.justahuman.more_cobblemon_tweaks.mixins;
 
 import com.cobblemon.mod.common.client.gui.pc.PCGUI;
+import com.cobblemon.mod.common.client.gui.pc.StorageWidget;
 import com.cobblemon.mod.common.util.MiscUtilsKt;
 import me.justahuman.more_cobblemon_tweaks.config.ModConfig;
 import me.justahuman.more_cobblemon_tweaks.features.pc.IvWidget;
@@ -40,6 +41,9 @@ public abstract class PcGuiMixin extends Screen {
     @Unique private RenameWidget moreCobblemonTweaks$renameWidget;
     @Unique private SearchWidget moreCobblemonTweaks$searchWidget;
 
+    @Shadow(remap = false) private int openOnBox;
+    @Shadow(remap = false) private StorageWidget storageWidget;
+
     protected PcGuiMixin(Component title) {
         super(title);
     }
@@ -74,6 +78,12 @@ public abstract class PcGuiMixin extends Screen {
         if (ModConfig.isEnabled("pc_search")) {
             siblings.add(this.addRenderableWidget(new SearchButton(x + 82, y - 13, siblings)));
             siblings.add(this.addRenderableWidget(moreCobblemonTweaks$searchWidget = new SearchWidget(x + 104, y - 13)));
+        }
+
+        // Due to the new `/pc box` logic, if the player uses `/pc` without specifying a box number, openOnBox defaults to 0,
+        // meaning we should use the last selected box (Utils.currentBox).
+        if (this.openOnBox == 0) {
+            this.storageWidget.setBox(Utils.currentBox);
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
-mod_version = 1.0.2
+mod_version = 1.0.2.1
 maven_group = me.justahuman
 archives_name = MoreCobblemonTweaks
 enabled_platforms = fabric,neoforge
@@ -14,6 +14,6 @@ fabric_loader_version = 0.16.9
 fabric_api_version = 0.107.0+1.21.1
 neoforge_version = 21.1.1
 
-cobblemon_version = 1.6.0+1.21.1
+cobblemon_version = 1.6.1+1.21.1
 cloth_config_version = 16.0.141
 modmenu_version=11.0.1


### PR DESCRIPTION
- Fixed an issue where the last saved box was incorrectly overridden when using `/pc` due to the new `/pc <number>` logic defaulting to box 0 when a box isn't provided.
- Updated `mod_version` to `1.0.2.1` to reflect the fix.
- Updated `cobblemon_version` from `1.6.0+1.21.1` to `1.6.1+1.21.1` for compatibility.