### PR TITLE
Add sort-all-boxes buttons to the box list view

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ BetterBreeding: Most<br>
     - Right-clicking a box will open the box view for that box.
     - Using the wallpaper options in the box list view will change the wallpaper for all boxes on the current page.
     - You can also use the search/filter while in the box list view and will filter the boxes based on if any pokemon in the box match the filter.
+    - While in the box list view, the sort buttons will sort every pokemon across all of your boxes (instead of just the currently opened box).
     - ![Screenshot of box list view](.assets/box_management.png)
     - ![Screenshot of boxes swapping](.assets/box_management_swapping.png)
   - Multiselect Move & Release

--- a/common/src/main/java/me/justahuman/more_cobblemon_tweaks/api/BoxViewHolder.java
+++ b/common/src/main/java/me/justahuman/more_cobblemon_tweaks/api/BoxViewHolder.java
@@ -1,9 +1,11 @@
 package me.justahuman.more_cobblemon_tweaks.api;
 
+import com.cobblemon.mod.common.api.pokemon.PokemonSortMode;
 import me.justahuman.more_cobblemon_tweaks.features.pc.boxes.BoxListSlot;
 
 public interface BoxViewHolder {
     boolean moreCobblemonTweaks$isBoxListOpen();
     BoxListSlot moreCobblemonTweaks$getSelectedBoxListSlot();
     BoxListSlot moreCobblemonTweaks$getPreviewedBoxListSlot(double mouseX, double mouseY);
+    void moreCobblemonTweaks$sortAllBoxes(PokemonSortMode sortMode, boolean descending);
 }

--- a/common/src/main/java/me/justahuman/more_cobblemon_tweaks/api/ConditionalIconButton.java
+++ b/common/src/main/java/me/justahuman/more_cobblemon_tweaks/api/ConditionalIconButton.java
@@ -1,7 +1,10 @@
 package me.justahuman.more_cobblemon_tweaks.api;
 
+import net.minecraft.network.chat.Component;
+
 import java.util.function.Supplier;
 
 public interface ConditionalIconButton {
     void moreCobblemonTweaks$setCondition(Supplier<Boolean> condition);
+    void moreCobblemonTweaks$setTooltip(Supplier<Component> tooltip);
 }

--- a/common/src/main/java/me/justahuman/more_cobblemon_tweaks/mixins/pc/IconButtonMixin.java
+++ b/common/src/main/java/me/justahuman/more_cobblemon_tweaks/mixins/pc/IconButtonMixin.java
@@ -2,6 +2,7 @@ package me.justahuman.more_cobblemon_tweaks.mixins.pc;
 
 import com.cobblemon.mod.common.client.gui.pc.IconButton;
 import me.justahuman.more_cobblemon_tweaks.api.ConditionalIconButton;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
@@ -16,6 +17,7 @@ import java.util.function.Supplier;
 @Mixin(value = IconButton.class)
 public class IconButtonMixin extends Button implements ConditionalIconButton {
     @Unique private Supplier<Boolean> moreCobblemonTweaks$condition = () -> true;
+    @Unique private Supplier<Component> moreCobblemonTweaks$tooltip = null;
 
     private IconButtonMixin(int i, int j, int k, int l, Component component, OnPress onPress, CreateNarration createNarration) {
         super(i, j, k, l, component, onPress, createNarration);
@@ -25,6 +27,13 @@ public class IconButtonMixin extends Button implements ConditionalIconButton {
     public void hideIfNeeded(GuiGraphics context, int mouseX, int mouseY, float partialTicks, CallbackInfo ci) {
         if (!moreCobblemonTweaks$condition.get()) {
             ci.cancel();
+        }
+    }
+
+    @Inject(method = "renderWidget", at = @At("TAIL"))
+    public void renderCustomTooltip(GuiGraphics context, int mouseX, int mouseY, float partialTicks, CallbackInfo ci) {
+        if (moreCobblemonTweaks$tooltip != null && isHovered()) {
+            context.renderTooltip(Minecraft.getInstance().font, moreCobblemonTweaks$tooltip.get(), mouseX, mouseY);
         }
     }
 
@@ -38,5 +47,10 @@ public class IconButtonMixin extends Button implements ConditionalIconButton {
     @Override
     public void moreCobblemonTweaks$setCondition(Supplier<Boolean> condition) {
         this.moreCobblemonTweaks$condition = condition;
+    }
+
+    @Override
+    public void moreCobblemonTweaks$setTooltip(Supplier<Component> tooltip) {
+        this.moreCobblemonTweaks$tooltip = tooltip;
     }
 }

--- a/common/src/main/java/me/justahuman/more_cobblemon_tweaks/mixins/pc/PcGuiMixin.java
+++ b/common/src/main/java/me/justahuman/more_cobblemon_tweaks/mixins/pc/PcGuiMixin.java
@@ -1,5 +1,6 @@
 package me.justahuman.more_cobblemon_tweaks.mixins.pc;
 
+import com.cobblemon.mod.common.api.pokemon.PokemonSortMode;
 import com.cobblemon.mod.common.client.gui.pasture.PasturePCGUIConfiguration;
 import com.cobblemon.mod.common.client.gui.pc.BoxNameWidget;
 import com.cobblemon.mod.common.client.gui.pc.FilterWidget;
@@ -45,8 +46,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+
+import static com.cobblemon.mod.common.util.MiscUtilsKt.cobblemonResource;
 
 @Mixin(value = PCGUI.class, priority = 2000)
 public abstract class PcGuiMixin extends Screen implements MultiSelectorState {
@@ -66,6 +70,8 @@ public abstract class PcGuiMixin extends Screen implements MultiSelectorState {
     @Final
     private static ResourceLocation portraitBackgroundResource;
     @Unique private MultiSelectButton moreCobblemonTweaks$multiSelectButton;
+    @Unique private final List<IconButton> moreCobblemonTweaks$vanillaSortButtons = new ArrayList<>();
+    @Unique private final List<IconButton> moreCobblemonTweaks$boxListSortButtons = new ArrayList<>();
 
     protected PcGuiMixin(Component title) {
         super(title);
@@ -102,6 +108,35 @@ public abstract class PcGuiMixin extends Screen implements MultiSelectorState {
                     BoxViewHolder boxViewHolder = (BoxViewHolder) (Object) storageWidget;
                     return boxViewHolder == null || !boxViewHolder.moreCobblemonTweaks$isBoxListOpen();
                 });
+                moreCobblemonTweaks$vanillaSortButtons.add(iconButton);
+            }
+        }
+
+        if (ModConfig.isEnabled("pc_box_view") && !(configuration instanceof PasturePCGUIConfiguration)) {
+            for (PokemonSortMode sortMode : PokemonSortMode.values()) {
+                String typeName = sortMode.name().toLowerCase(Locale.ROOT);
+                Component tooltip = Component.translatable("more_cobblemon_tweaks.pc_enhancements.box_list.sort." + typeName);
+                IconButton sortAllButton = new IconButton(
+                        x + 92 + (12 * sortMode.ordinal()),
+                        y + 31,
+                        20,
+                        20,
+                        cobblemonResource("textures/gui/pc/pc_button_sort_" + typeName + ".png"),
+                        cobblemonResource("textures/gui/pc/pc_button_sort_" + typeName + "_reverse.png"),
+                        null,
+                        "box_list_sort_" + typeName,
+                        button -> {
+                            storageWidget.resetSelected();
+                            ((BoxViewHolder) (Object) storageWidget).moreCobblemonTweaks$sortAllBoxes(sortMode, Screen.hasShiftDown());
+                        }
+                );
+                ConditionalIconButton conditional = (ConditionalIconButton) (Object) sortAllButton;
+                conditional.moreCobblemonTweaks$setCondition(() ->
+                        ((BoxViewHolder) (Object) storageWidget).moreCobblemonTweaks$isBoxListOpen() && cast().getDisplayOptions()
+                );
+                conditional.moreCobblemonTweaks$setTooltip(() -> tooltip);
+                moreCobblemonTweaks$boxListSortButtons.add(sortAllButton);
+                this.addRenderableWidget(sortAllButton);
             }
         }
     }
@@ -169,6 +204,17 @@ public abstract class PcGuiMixin extends Screen implements MultiSelectorState {
     public void captureMousePos(GuiGraphics context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         moreCobblemonTweaks$mouseX = mouseX;
         moreCobblemonTweaks$mouseY = mouseY;
+
+        if (storageWidget != null && !(moreCobblemonTweaks$vanillaSortButtons.isEmpty() && moreCobblemonTweaks$boxListSortButtons.isEmpty())) {
+            boolean boxListOpen = ((BoxViewHolder) (Object) storageWidget).moreCobblemonTweaks$isBoxListOpen();
+            boolean displayOptions = cast().getDisplayOptions();
+            for (IconButton button : moreCobblemonTweaks$vanillaSortButtons) {
+                button.visible = displayOptions && !boxListOpen;
+            }
+            for (IconButton button : moreCobblemonTweaks$boxListSortButtons) {
+                button.visible = displayOptions && boxListOpen;
+            }
+        }
     }
 
     @WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Lcom/cobblemon/mod/common/api/gui/GuiUtilsKt;blitk$default(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/resources/ResourceLocation;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ZFILjava/lang/Object;)V"))

--- a/common/src/main/java/me/justahuman/more_cobblemon_tweaks/mixins/pc/StorageWidgetMixin.java
+++ b/common/src/main/java/me/justahuman/more_cobblemon_tweaks/mixins/pc/StorageWidgetMixin.java
@@ -4,6 +4,7 @@ import com.cobblemon.mod.common.CobblemonNetwork;
 import com.cobblemon.mod.common.CobblemonSounds;
 import com.cobblemon.mod.common.api.gui.GuiUtilsKt;
 import com.cobblemon.mod.common.api.net.NetworkPacket;
+import com.cobblemon.mod.common.api.pokemon.PokemonSortMode;
 import com.cobblemon.mod.common.api.storage.pc.PCPosition;
 import com.cobblemon.mod.common.client.CobblemonResources;
 import com.cobblemon.mod.common.client.gui.PokemonGuiUtilsKt;
@@ -73,6 +74,8 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+
+import static com.cobblemon.mod.common.api.storage.pc.ConstantsKt.POKEMON_PER_BOX;
 
 @Mixin(value = StorageWidget.class, remap = false)
 public abstract class StorageWidgetMixin extends SoundlessWidget implements MultiSelector, BoxViewHolder {
@@ -676,6 +679,30 @@ public abstract class StorageWidgetMixin extends SoundlessWidget implements Mult
         this.moreCobblemonTweaks$boxListSlots.forEach(widget -> removeWidget(widget));
         this.moreCobblemonTweaks$boxListSlots.clear();
         moreCobblemonTweaks$boxListSlotIndex = 30 * box;
+    }
+
+    @Override
+    public void moreCobblemonTweaks$sortAllBoxes(PokemonSortMode sortMode, boolean descending) {
+        ClientPC pc = pcGui.getPc();
+        List<Pokemon> allPokemon = new ArrayList<>();
+        for (ClientBox clientBox : pc.getBoxes()) {
+            for (Pokemon pokemon : clientBox.getSlots()) {
+                if (pokemon != null) {
+                    allPokemon.add(pokemon);
+                }
+            }
+        }
+        allPokemon.sort(sortMode.comparator(descending));
+
+        Map<Pokemon, PCPosition> moves = new LinkedHashMap<>();
+        for (int i = 0; i < allPokemon.size(); i++) {
+            moves.put(allPokemon.get(i), new PCPosition(i / POKEMON_PER_BOX, i % POKEMON_PER_BOX));
+        }
+
+        playSound(CobblemonSounds.PC_CLICK);
+        resetSelected();
+        moreCobblemonTweaks$clearMultiSelection();
+        moreCobblemonTweaks$handleMultiPokemonMoves(moves);
     }
 
     @Override

--- a/common/src/main/resources/assets/more_cobblemon_tweaks/lang/en_us.json
+++ b/common/src/main/resources/assets/more_cobblemon_tweaks/lang/en_us.json
@@ -44,6 +44,12 @@
   "more_cobblemon_tweaks.pc_enhancements.box_list.button.enabled": "Box View",
   "more_cobblemon_tweaks.pc_enhancements.box_list.title": "Box List %1$s-%2$s",
 
+  "more_cobblemon_tweaks.pc_enhancements.box_list.sort.name": "Sort All Boxes by Name",
+  "more_cobblemon_tweaks.pc_enhancements.box_list.sort.level": "Sort All Boxes by Level",
+  "more_cobblemon_tweaks.pc_enhancements.box_list.sort.type": "Sort All Boxes by Type",
+  "more_cobblemon_tweaks.pc_enhancements.box_list.sort.pokedex_number": "Sort All Boxes by Pokédex Number",
+  "more_cobblemon_tweaks.pc_enhancements.box_list.sort.gender": "Sort All Boxes by Gender",
+
   "more_cobblemon_tweaks.pc_enhancements.multi_move.title": "Moving %1$s/%2$s Pokémon...",
   "more_cobblemon_tweaks.pc_enhancements.multi_move.timeout": "Timed out %1$s time(s), Retrying...",
   "more_cobblemon_tweaks.pc_enhancements.multi_move.last_attempt": "Timed out %1$s times, Last attempt",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
-mod_version = 1.3.3
+mod_version = 1.3.4
 maven_group = me.justahuman
 archives_name = MoreCobblemonTweaks
 enabled_platforms = fabric,neoforge


### PR DESCRIPTION
## Summary
- When the box list view is open, the existing per-box sort buttons are hidden (sorting a single "page" doesn't make sense there). This adds an equivalent set of sort buttons in the same position that sort every Pokemon across **all** boxes (by name, level, type, pokedex number, or gender) instead of just the currently opened box.
- Reuses the existing multi-move packet flow already used for box swapping in the box list view, so it works with vanilla Cobblemon's server-side packets without needing a new custom packet.
- Bumped version to 1.3.4.

## Test plan
- [x] Filled a PC with dozens of unsorted Pokemon spanning multiple boxes
- [x] Opened the box list view and confirmed the new sort buttons appear in the same spot as the normal sort buttons, with correct tooltips
- [x] Clicked "Sort All Boxes by Pokédex Number" and confirmed Pokemon were reordered in ascending dex order across box boundaries (not just within a single box)
- [x] Sort by name/level/type/gender in box list view 